### PR TITLE
カードスロット消失バグの解消

### DIFF
--- a/Assets/Scripts/BattleManager.cs
+++ b/Assets/Scripts/BattleManager.cs
@@ -120,6 +120,7 @@ public class BattleManager : MonoBehaviour
     {
         var card = new CardModel(CardData.CardDataArrayList[cardID]);
         Debug.Log("ID"+cardID);
+        await UniTask.Delay(10);
         Debug.Log("Attack"+card.Attack);
         await player.CanMove(cardID);
     }


### PR DESCRIPTION
### 変更点

> Delayを使って処理速度を落とし、カード消失バグを直した。
根本的な原因は不明だが、よくあることらしい